### PR TITLE
fix word before to begin for correct long options parsing

### DIFF
--- a/retdo
+++ b/retdo
@@ -16,7 +16,7 @@
     # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
  
-PARSED_OPTIONS=$(getopt -n "$0"  -o hp:a:b:e:r:d:vs --long "help,path:,action:,before:,end:,regexp:,delta:,verbose,simulate"  -- "$@")
+PARSED_OPTIONS=$(getopt -n "$0"  -o hp:a:b:e:r:d:vs --long "help,path:,action:,begin:,end:,regexp:,delta:,verbose,simulate"  -- "$@")
 
 
 function usage()


### PR DESCRIPTION
There's a small bug when using long options, so I fixed this in my commit. For example, if you use long options in the command with word "before" it doesn't recognize it:
`retdo --path /data/backups/DB --regexp \"*.tgz\" --before 90 --end 181 --delta 7`

This one does work, as the parsed option from should be called "begin"
`retdo --path /data/backups/DB --regexp \"*.tgz\" --begin 90 --end 181 --delta 7`